### PR TITLE
Added Return Types

### DIFF
--- a/src/Savvy/ObjectProxy.php
+++ b/src/Savvy/ObjectProxy.php
@@ -199,7 +199,7 @@ class Savvy_ObjectProxy implements Countable
      *
      * @return int
      */
-    public function count()
+    public function count():int
     {
         return count($this->object);
     }

--- a/src/Savvy/ObjectProxy/ArrayAccess.php
+++ b/src/Savvy/ObjectProxy/ArrayAccess.php
@@ -1,22 +1,23 @@
 <?php
 class Savvy_ObjectProxy_ArrayAccess extends Savvy_ObjectProxy implements ArrayAccess
 {
-    public function offsetExists($offset)
+    public function offsetExists($offset):bool
     {
         return $this->object->offsetExists($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->filterVar($this->object->offsetGet($offset));
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value):void
     {
         $this->object->offsetSet($offset, $value);
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset($offset):void
     {
         $this->object->offsetUnset($offset);
     }

--- a/src/Savvy/ObjectProxy/ArrayIterator.php
+++ b/src/Savvy/ObjectProxy/ArrayIterator.php
@@ -15,6 +15,7 @@ class Savvy_ObjectProxy_ArrayIterator extends Savvy_ObjectProxy_TraversableArray
         parent::__construct($array, $savvy);
     }
 
+    #[\ReturnTypeWillChange]
     public function seek($offset)
     {
         return $this->getInnerIterator()->seek($offset);

--- a/src/Savvy/ObjectProxy/Traversable.php
+++ b/src/Savvy/ObjectProxy/Traversable.php
@@ -20,7 +20,7 @@ class Savvy_ObjectProxy_Traversable extends Savvy_ObjectProxy implements OuterIt
      * @inheritDoc
      * @return Iterator
      */
-    public function getInnerIterator()
+    public function getInnerIterator():?Iterator
     {
         if ($this->innerIterator) {
             return $this->innerIterator;
@@ -29,32 +29,34 @@ class Savvy_ObjectProxy_Traversable extends Savvy_ObjectProxy implements OuterIt
         return $this->object;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->filterVar($this->getInnerIterator()->current());
     }
 
-    public function next()
+    public function next():void
     {
         $this->getInnerIterator()->next();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->filterVar($this->getInnerIterator()->key());
     }
 
-    public function valid()
+    public function valid():bool
     {
         return $this->getInnerIterator()->valid();
     }
 
-    public function rewind()
+    public function rewind():bool
     {
         $this->getInnerIterator()->rewind();
     }
 
-    public function count()
+    public function count():int
     {
         if ($this->getInnerIterator() instanceof Countable) {
             return count($this->getInnerIterator());

--- a/src/Savvy/ObjectProxy/TraversableArrayAccess.php
+++ b/src/Savvy/ObjectProxy/TraversableArrayAccess.php
@@ -20,7 +20,7 @@ class Savvy_ObjectProxy_TraversableArrayAccess extends Savvy_ObjectProxy_ArrayAc
      * @inheritDoc
      * @return Iterator
      */
-    public function getInnerIterator()
+    public function getInnerIterator():?Iterator
     {
         if ($this->innerIterator) {
             return $this->innerIterator;
@@ -29,27 +29,29 @@ class Savvy_ObjectProxy_TraversableArrayAccess extends Savvy_ObjectProxy_ArrayAc
         return $this->object;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->filterVar($this->getInnerIterator()->current());
     }
 
-    public function next()
+    public function next():void
     {
         $this->getInnerIterator()->next();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->filterVar($this->getInnerIterator()->key());
     }
 
-    public function valid()
+    public function valid():bool
     {
         return $this->getInnerIterator()->valid();
     }
 
-    public function rewind()
+    public function rewind():void
     {
         $this->getInnerIterator()->rewind();
     }


### PR DESCRIPTION
When updating to php 8.1 I got lots of Deprecated notices.
- Added return types for iterators
- Added #[\ReturnTypeWillChange] attribute to some functions